### PR TITLE
Cuppajoeman/regexfix

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,10 +29,34 @@ try{
 	return
 }
 
+// Get pandoc
+// const pandocBaseUrl = "https://github.com/corollari/caoutchouc/raw/master/vendor"
+// const pandoc = new BinWrapper()
+// 	.src(`${pandocBaseUrl}/osx/pandoc`, 'darwin')
+//     .src(`${pandocBaseUrl}/linux/pandoc`, 'linux')
+//     .src(`${pandocBaseUrl}/win/x86/pandoc.exe`, 'win32', 'x86')
+//     .src(`${pandocBaseUrl}/win/x64/pandoc.exe`, 'win32', 'x64')
+//     .dest(path.join(__dirname, 'pandoc'))
+//     .use(process.platform === 'win32' ? 'pandoc.exe' : 'pandoc')
+// 
+// if(fs.existsSync(pandoc.path())){
+// 	compile(input, typesetter, inputFile, pandoc.path())
+// } else {
+// 	console.log('⧗ Downloading Pandoc (~20-50MB depending on OS). This may take a minute or so.');
+// 	(async () => {
+// 		try{
+// 			await pandoc.run(['--version'])
+// 		} catch(e){
+// 			console.error('✗ pandoc installation failed')
+// 			return 1
+// 		}
+// 		compile(input, typesetter, inputFile, pandoc.path())
+// 	})();
+// }
 
-compile(input, typesetter, inputFile)
+compile(input, typesetter, inputFile, "pandoc")
 
-function compile(input, typesetter, inputFile){
+function compile(input, typesetter, inputFile, pandocPath){
 	input=replaceLiteral(input, "€€", "$$asciimath", "asciimath$$")
 	input=replaceLiteral(input, "€", "$asciimath", "asciimath$")
 	//input=replaceLiteral(input, "$$$", "```{=latex}", "```")
@@ -42,7 +66,7 @@ function compile(input, typesetter, inputFile){
 	[usepackages, input]=removeUsePackage(input)
 
 
-	let result = child_process.spawnSync("pandoc", ["-t", "latex", "-f", "markdown+lists_without_preceding_blankline+hard_line_breaks+raw_tex+raw_attribute", "-s", "--filter", "caou-pandoc-filter"], { input: input }).stdout
+	let result = child_process.spawnSync(pandocPath, ["-t", "latex", "-f", "markdown+lists_without_preceding_blankline+hard_line_breaks+raw_tex+raw_attribute", "-s", "--filter", "caou-pandoc-filter"], { input: input }).stdout
 
 	result=String(result)
 
@@ -51,7 +75,7 @@ function compile(input, typesetter, inputFile){
 	result=result.replace(/asciimath\$\$/g, "€€")
 	result=result.replace(/asciimath\$/g, "€")
 
-	result=result.replace(/(\\documentclass.*?})/gs, "$1\n"+usepackages)
+ 	result=result.replace(/(\\documentclass.*?})/gs, "$1\n"+usepackages)
 
 	let filename = path.basename(inputFile).split(".")
 	const extension = filename.pop()

--- a/index.js
+++ b/index.js
@@ -29,32 +29,10 @@ try{
 	return
 }
 
-// Get pandoc
-const pandocBaseUrl = "https://github.com/corollari/caoutchouc/raw/master/vendor"
-const pandoc = new BinWrapper()
-	.src(`${pandocBaseUrl}/osx/pandoc`, 'darwin')
-    .src(`${pandocBaseUrl}/linux/pandoc`, 'linux')
-    .src(`${pandocBaseUrl}/win/x86/pandoc.exe`, 'win32', 'x86')
-    .src(`${pandocBaseUrl}/win/x64/pandoc.exe`, 'win32', 'x64')
-    .dest(path.join(__dirname, 'pandoc'))
-    .use(process.platform === 'win32' ? 'pandoc.exe' : 'pandoc')
 
-if(fs.existsSync(pandoc.path())){
-	compile(input, typesetter, inputFile, pandoc.path())
-} else {
-	console.log('⧗ Downloading Pandoc (~20-50MB depending on OS). This may take a minute or so.');
-	(async () => {
-		try{
-			await pandoc.run(['--version'])
-		} catch(e){
-			console.error('✗ pandoc installation failed')
-			return 1
-		}
-		compile(input, typesetter, inputFile, pandoc.path())
-	})();
-}
+compile(input, typesetter, inputFile)
 
-function compile(input, typesetter, inputFile, pandocPath){
+function compile(input, typesetter, inputFile){
 	input=replaceLiteral(input, "€€", "$$asciimath", "asciimath$$")
 	input=replaceLiteral(input, "€", "$asciimath", "asciimath$")
 	//input=replaceLiteral(input, "$$$", "```{=latex}", "```")
@@ -64,7 +42,7 @@ function compile(input, typesetter, inputFile, pandocPath){
 	[usepackages, input]=removeUsePackage(input)
 
 
-	let result = child_process.spawnSync(pandocPath, ["-t", "latex", "-f", "markdown+lists_without_preceding_blankline+hard_line_breaks+raw_tex+raw_attribute", "-s", "--filter", "caou-pandoc-filter"], { input: input }).stdout
+	let result = child_process.spawnSync("pandoc", ["-t", "latex", "-f", "markdown+lists_without_preceding_blankline+hard_line_breaks+raw_tex+raw_attribute", "-s", "--filter", "caou-pandoc-filter"], { input: input }).stdout
 
 	result=String(result)
 
@@ -73,7 +51,7 @@ function compile(input, typesetter, inputFile, pandocPath){
 	result=result.replace(/asciimath\$\$/g, "€€")
 	result=result.replace(/asciimath\$/g, "€")
 
-	result=result.replace(/(\\documentclass.*)/g, "$1\n"+usepackages)
+	result=result.replace(/(\\documentclass.*?})/gs, "$1\n"+usepackages)
 
 	let filename = path.basename(inputFile).split(".")
 	const extension = filename.pop()


### PR DESCRIPTION
Hi, I believe I found the problem with caoutchouc not working with the newest version of pandoc or at least I have a fix for one of the errors that was occuring. It turns out the regex for adding the packages back in did some weird things, for example, the one that was in there are the start was like this

![](https://i.imgur.com/DpWlIgE.png)

So for some reason what pandoc produces has a line break right there, and of course it inserted a `/includepackage{...}` on the next line which totally messed things up.

I've modified it so it works like this (the /s at the end makes the `.` match newlines)

![](https://i.imgur.com/9gOAnQK.png)

This is my first real pull request so let me know if I should change anything, as I did uncomment the whole pandoc section since I didn't want it to try to download an outdated version on my computer.

